### PR TITLE
AutoComplete: Index was outside the bounds of the array.

### DIFF
--- a/src/ReadLine.Demo/Program.cs
+++ b/src/ReadLine.Demo/Program.cs
@@ -15,7 +15,7 @@ namespace ConsoleApplication
 
             ReadLine.AutoCompletionHandler = (t, s) =>
             {
-                if (t.StartsWith("git"))
+                if (t.StartsWith("git "))
                     return new string[] { "init", "clone", "pull", "push" };
                 else
                     return null;

--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -162,6 +162,12 @@ namespace System
             }
         }
 
+        private void ResetAutoComplete()
+        {
+            _completions = null;
+            _completionsIdx = 0;
+        }
+
         public string Text
         {
             get
@@ -242,7 +248,7 @@ namespace System
 
             // If in auto complete mode and Tab wasn't pressed
             if (IsInAutoCompleteMode() && _keyInfo.Key != ConsoleKey.Tab)
-                _completions = null;
+                ResetAutoComplete();
 
             Action action;
             _keyActions.TryGetValue(BuildKeyInput(), out action);


### PR DESCRIPTION
This PR provides a fix for the autocomplete index out of range exception. Now resets `_completionsIdx` to zero along with completion array.

Fixes #3 