### PR TITLE
Console abstraction

### DIFF
--- a/src/ReadLine/Abstractions/Console2.cs
+++ b/src/ReadLine/Abstractions/Console2.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Internal.ReadLine.Abstractions
+{
+    internal class Console2 : IConsole
+    {
+        public int CursorLeft => Console.CursorLeft;
+
+        public int CursorTop => Console.CursorTop;
+
+        public int BufferWidth => Console.BufferWidth;
+
+        public int BufferHeight => Console.BufferHeight;
+
+        public void SetBufferSize(int width, int height) => Console.SetBufferSize(width, height);
+
+        public void SetCursorPosition(int left, int top) => Console.SetCursorPosition(left, top);
+
+        public void Write(string value) => Console.Write(value);
+
+        public void WriteLine(string value) => Console.WriteLine(value);
+    }
+}

--- a/src/ReadLine/Abstractions/IConsole.cs
+++ b/src/ReadLine/Abstractions/IConsole.cs
@@ -1,0 +1,14 @@
+namespace Internal.ReadLine.Abstractions
+{
+    internal interface IConsole
+    {
+        int CursorLeft { get; }
+        int CursorTop { get; }
+        int BufferWidth { get; }
+        int BufferHeight { get; }
+        void SetCursorPosition(int left, int top);
+        void SetBufferSize(int width, int height);
+        void Write(string value);
+        void WriteLine(string value);
+    }
+}

--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace System
+namespace Internal.ReadLine
 {
     internal class KeyHandler
     {

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -1,4 +1,6 @@
 ﻿using Internal.ReadLine;
+using Internal.ReadLine.Abstractions;
+
 using System.Collections.Generic;
 
 namespace System
@@ -23,7 +25,7 @@ namespace System
         {
             Console.Write(prompt);
 
-            _keyHandler = new KeyHandler(_history, AutoCompletionHandler);
+            _keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
             ConsoleKeyInfo keyInfo = Console.ReadKey(true);
 
             while (keyInfo.Key != ConsoleKey.Enter)

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Internal.ReadLine;
+using System.Collections.Generic;
 
 namespace System
 {
@@ -21,8 +22,10 @@ namespace System
         public static string Read(string prompt = "")
         {
             Console.Write(prompt);
+
             _keyHandler = new KeyHandler(_history, AutoCompletionHandler);
             ConsoleKeyInfo keyInfo = Console.ReadKey(true);
+
             while (keyInfo.Key != ConsoleKey.Enter)
             {
                 _keyHandler.Handle(keyInfo);
@@ -30,10 +33,9 @@ namespace System
             }
 
             Console.WriteLine();
-            string text = _keyHandler.Text;
-            _history.Add(text);
 
-            return text;
+            _history.Add(_keyHandler.Text);
+            return _keyHandler.Text;
         }
     }
 }


### PR DESCRIPTION
This PR abstracts `System.Console` using the `IConsole` interface. 
This change is purely to enable writing more comprehensive tests. However, this also lays the groundwork for using this library in places where there isn't actually a console window