### PR TITLE
Add backwards AutoComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is cross platform and runs anywhere .NET is supported, targeting `netstandard
 | `Ctrl`+`F` / `→`               | Forward one character             |
 | `Ctrl`+`H` / `Backspace`       | Delete previous character         |
 | `Tab`                          | Command line completion           |
+| `Shift`+`Tab`                  | Backwards command line completion |
 | `Ctrl`+`J` / `Enter`           | Line feed                         |
 | `Ctrl`+`K`                     | Cut text to the end of line       |
 | `Ctrl`+`L`                     | Clear line                        |

--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -50,7 +50,7 @@ namespace Internal.ReadLine
 
         private string BuildKeyInput()
         {
-            return _keyInfo.Modifiers != ConsoleModifiers.Control ?
+            return (_keyInfo.Modifiers != ConsoleModifiers.Control && _keyInfo.Modifiers != ConsoleModifiers.Shift) ?
                 _keyInfo.Key.ToString() : _keyInfo.Modifiers.ToString() + _keyInfo.Key.ToString();
         }
 
@@ -133,16 +133,40 @@ namespace Internal.ReadLine
             }
         }
 
-        private void AutoComplete()
+        private void StartAutoComplete()
         {
             while (_cursorPos > _completionStart)
                 Backspace();
 
+            _completionsIndex = 0;
+
             WriteString(_completions[_completionsIndex]);
+        }
+
+        private void NextAutoComplete()
+        {
+            while (_cursorPos > _completionStart)
+                Backspace();
+
             _completionsIndex++;
 
             if (_completionsIndex == _completions.Length)
                 _completionsIndex = 0;
+
+            WriteString(_completions[_completionsIndex]);
+        }
+
+        private void PreviousAutoComplete()
+        {
+            while (_cursorPos > _completionStart)
+                Backspace();
+
+            _completionsIndex--;
+
+            if (_completionsIndex == -1)
+                _completionsIndex = _completions.Length - 1;
+
+            WriteString(_completions[_completionsIndex]);
         }
 
         private void PrevHistory()
@@ -226,7 +250,7 @@ namespace Internal.ReadLine
             {
                 if (IsInAutoCompleteMode())
                 {
-                    AutoComplete();
+                    NextAutoComplete();
                 }
                 else
                 {
@@ -243,7 +267,15 @@ namespace Internal.ReadLine
                     if (_completions == null || _completions.Length == 0)
                         return;
 
-                    AutoComplete();
+                    StartAutoComplete();
+                }
+            };
+
+            _keyActions["ShiftTab"] = () =>
+            {
+                if (IsInAutoCompleteMode())
+                {
+                    PreviousAutoComplete();
                 }
             };
         }

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -366,5 +366,38 @@ namespace ReadLine.Tests
                 Assert.Equal($"Hi {_completions[i]}", _keyHandler.Text);
             }
         }
+
+        [Fact]
+        public void TestBackwardsTab()
+        {
+            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+            _keyHandler.Handle(_keyInfo);
+
+            // Nothing happens when no auto complete handler is set
+            Assert.Equal("Hello", _keyHandler.Text);
+
+            _keyHandler = new KeyHandler(new Console2(), _history, (t, s) => _completions);
+
+            _keyInfo = new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false);
+            _keyHandler.Handle(_keyInfo);
+
+            _keyInfo = new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false);
+            _keyHandler.Handle(_keyInfo);
+
+            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+            _keyHandler.Handle(_keyInfo);
+
+            // Bring up the first Autocomplete
+            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+            _keyHandler.Handle(_keyInfo);
+
+            for (int i = _completions.Length - 1; i >= 0; i--)
+            {
+                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
+                _keyHandler.Handle(_keyInfo);
+
+                Assert.Equal($"Hi {_completions[i]}", _keyHandler.Text);
+            }
+        }
     }
 }


### PR DESCRIPTION
Pressing Shift-Tab will traverse the autocomplete list in backward order, in case you missed it when mashing tab. I had to modify a couple of methods so it'd work, let me know if you'd prefer it another way.
Also, the `BuildKeyInput` method could be cleaner at detecting key modifiers, but I'll leave it at your discretion.
Feature requested by #6 