### PR TITLE
Refactor Tests

### DIFF
--- a/test/ReadLine.Tests/CharExtensions.cs
+++ b/test/ReadLine.Tests/CharExtensions.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace ReadLine.Tests
+{
+    public static class CharExtensions
+    {
+        public const char ExclamationPoint = '!';
+        public const char Space = ' ';
+
+        public const char CtrlA = '\u0001';
+        public const char CtrlB = '\u0002';
+        public const char CtrlD = '\u0004';
+        public const char CtrlE = '\u0005';
+        public const char CtrlF = '\u0006';
+        public const char CtrlH = '\u0008';
+        public const char CtrlK = '\u000B';
+        public const char CtrlL = '\u000C';
+        public const char CtrlN = '\u000E';
+        public const char CtrlP = '\u0010';
+        public const char CtrlT = '\u0014';
+        public const char CtrlU = '\u0015';
+        public const char CtrlW = '\u0017';
+
+        private static readonly Dictionary<char, Tuple<ConsoleKey, ConsoleModifiers>> specialKeyCharMap = new Dictionary<char, Tuple<ConsoleKey, ConsoleModifiers>>() 
+        {
+            {ExclamationPoint, Tuple.Create(ConsoleKey.D0, NoModifiers())},
+            {Space, Tuple.Create(ConsoleKey.Spacebar,  NoModifiers())},
+            {CtrlA, Tuple.Create(ConsoleKey.A, ConsoleModifiers.Control)},
+            {CtrlB, Tuple.Create(ConsoleKey.B, ConsoleModifiers.Control)},
+            {CtrlD, Tuple.Create(ConsoleKey.D, ConsoleModifiers.Control)},
+            {CtrlE, Tuple.Create(ConsoleKey.E, ConsoleModifiers.Control)},
+            {CtrlF, Tuple.Create(ConsoleKey.F, ConsoleModifiers.Control)},
+            {CtrlH, Tuple.Create(ConsoleKey.H, ConsoleModifiers.Control)},
+            {CtrlK, Tuple.Create(ConsoleKey.K, ConsoleModifiers.Control)},
+            {CtrlL, Tuple.Create(ConsoleKey.L, ConsoleModifiers.Control)},
+            {CtrlN, Tuple.Create(ConsoleKey.N, ConsoleModifiers.Control)},
+            {CtrlP, Tuple.Create(ConsoleKey.P, ConsoleModifiers.Control)},
+            {CtrlT, Tuple.Create(ConsoleKey.T, ConsoleModifiers.Control)},
+            {CtrlU, Tuple.Create(ConsoleKey.U, ConsoleModifiers.Control)},
+            {CtrlW, Tuple.Create(ConsoleKey.W, ConsoleModifiers.Control)}
+        };
+
+        public static ConsoleKeyInfo ToConsoleKeyInfo(this char c)
+        {
+            var (key, modifiers) = c.ParseKeyInfo();
+
+            var ctrl = modifiers.HasFlag(ConsoleModifiers.Control);
+            var shift = modifiers.HasFlag(ConsoleModifiers.Shift);
+            var alt = modifiers.HasFlag(ConsoleModifiers.Alt);
+
+            return new ConsoleKeyInfo(c, key, shift, alt, ctrl);
+        }
+
+        private static Tuple<ConsoleKey, ConsoleModifiers> ParseKeyInfo(this char c) 
+        {
+            {
+                var success = Enum.TryParse<ConsoleKey>(c.ToString().ToUpper(), out ConsoleKey result);
+                if (success) {return Tuple.Create(result, NoModifiers());}
+            }
+            
+            {
+                var success = specialKeyCharMap.TryGetValue(c, out Tuple<ConsoleKey, ConsoleModifiers> result);
+                if (success) { return result; }
+            }
+
+            //if all else fails, return whatever the default is
+            return Tuple.Create(default(ConsoleKey), NoModifiers());
+        }
+
+        private static ConsoleModifiers NoModifiers()
+        {
+            return (ConsoleModifiers)0;
+        }
+    }
+}

--- a/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
+++ b/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
@@ -18,5 +18,21 @@ namespace ReadLine.Tests
 
         public static readonly ConsoleKeyInfo Tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
         public static readonly ConsoleKeyInfo ShiftTab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
+
+        public static readonly ConsoleKeyInfo ExclamationPoint = CharExtensions.ExclamationPoint.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo Space = CharExtensions.Space.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlA = CharExtensions.CtrlA.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlB = CharExtensions.CtrlB.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlD = CharExtensions.CtrlD.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlE = CharExtensions.CtrlE.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlF = CharExtensions.CtrlF.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlH = CharExtensions.CtrlH.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlK = CharExtensions.CtrlK.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlL = CharExtensions.CtrlL.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlN = CharExtensions.CtrlN.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlP = CharExtensions.CtrlP.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlT = CharExtensions.CtrlT.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlU = CharExtensions.CtrlU.ToConsoleKeyInfo();
+        public static readonly ConsoleKeyInfo CtrlW = CharExtensions.CtrlW.ToConsoleKeyInfo();
     }
 }

--- a/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
+++ b/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace ReadLine.Tests
+{
+    public static class ConsoleKeyInfoExtensions
+    {
+        public static readonly ConsoleKeyInfo LeftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+    }
+}

--- a/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
+++ b/test/ReadLine.Tests/ConsoleKeyInfoExtensions.cs
@@ -5,6 +5,18 @@ namespace ReadLine.Tests
 {
     public static class ConsoleKeyInfoExtensions
     {
+        public static readonly ConsoleKeyInfo Backspace = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
+        public static readonly ConsoleKeyInfo Delete = new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false);
+
+        public static readonly ConsoleKeyInfo Home = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
+        public static readonly ConsoleKeyInfo End = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
+
         public static readonly ConsoleKeyInfo LeftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+        public static readonly ConsoleKeyInfo RightArrow = new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false);
+        public static readonly ConsoleKeyInfo UpArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
+        public static readonly ConsoleKeyInfo DownArrow = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+
+        public static readonly ConsoleKeyInfo Tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+        public static readonly ConsoleKeyInfo ShiftTab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
     }
 }

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -49,20 +49,15 @@ namespace ReadLine.Tests
         [Fact]
         public void TestBackspace()
         {
-            var backspace = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
-            _keyHandler.Handle(backspace);
-
+            _keyHandler.Handle(Backspace);
             Assert.Equal("Hell", _keyHandler.Text);
         }
 
         [Fact]
         public void TestDelete()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                LeftArrow,
-                new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false)
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { LeftArrow, Delete }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hell", _keyHandler.Text);
         }
@@ -70,9 +65,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestDelete_EndOfLine()
         {
-            var delete = new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false);
-            _keyHandler.Handle(delete);
-
+            _keyHandler.Handle(Delete);
             Assert.Equal("Hello", _keyHandler.Text);
         }
 
@@ -80,7 +73,6 @@ namespace ReadLine.Tests
         public void TestControlH()
         {
             _keyHandler.Handle(CtrlH.ToConsoleKeyInfo());
-
             Assert.Equal("Hell", _keyHandler.Text);
         }
 
@@ -99,11 +91,8 @@ namespace ReadLine.Tests
         {
             var initialCursorCol = _console.CursorLeft;
 
-            new List<ConsoleKeyInfo>()
-            {
-                LeftArrow,
-                CtrlT.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { LeftArrow, CtrlT.ToConsoleKeyInfo() }
+                .ForEach(_keyHandler.Handle);
             
             Assert.Equal("Helol", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -141,11 +130,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestHome()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false),
-                'S'.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { Home, 'S'.ToConsoleKeyInfo() }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("SHello", _keyHandler.Text);
         }
@@ -153,11 +139,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlA()
         {
-            new List<ConsoleKeyInfo>() 
-            {
-                CtrlA.ToConsoleKeyInfo(),
-                'S'.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { CtrlA.ToConsoleKeyInfo(), 'S'.ToConsoleKeyInfo() }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("SHello", _keyHandler.Text);
         }
@@ -165,12 +148,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestEnd()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false),
-                new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false),
-                ExclamationPoint.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { Home, End, ExclamationPoint.ToConsoleKeyInfo() }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -213,12 +192,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestRightArrow()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                LeftArrow,
-                new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false),
-                ExclamationPoint.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { LeftArrow, RightArrow, ExclamationPoint.ToConsoleKeyInfo() }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -258,7 +233,7 @@ namespace ReadLine.Tests
         public void TestUpArrow()
         {
             _history.AsEnumerable().Reverse().ToList().ForEach((history) => {
-                _keyHandler.Handle(new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false));
+                _keyHandler.Handle(UpArrow);
                 Assert.Equal(history, _keyHandler.Text);
             });
         }
@@ -275,23 +250,20 @@ namespace ReadLine.Tests
         [Fact]
         public void TestDownArrow()
         {
-            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-            Enumerable.Repeat(upArrow, _history.Count)
+            Enumerable.Repeat(UpArrow, _history.Count)
                     .ToList()
                     .ForEach(_keyHandler.Handle);
 
-            var downArrow = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
             _history.ForEach( history => {
                 Assert.Equal(history, _keyHandler.Text);
-                _keyHandler.Handle(downArrow);
+                _keyHandler.Handle(DownArrow);
             });
         }
 
         [Fact]
         public void TestControlN()
         {
-            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-            Enumerable.Repeat(upArrow, _history.Count)
+            Enumerable.Repeat(UpArrow, _history.Count)
                     .ToList()
                     .ForEach(_keyHandler.Handle);
 
@@ -309,8 +281,7 @@ namespace ReadLine.Tests
 
             Assert.Equal("o", _keyHandler.Text);
 
-            var end = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
-            _keyHandler.Handle(end);
+            _keyHandler.Handle(End);
             _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
@@ -324,8 +295,7 @@ namespace ReadLine.Tests
 
             Assert.Equal("Hell", _keyHandler.Text);
 
-            var home = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
-            _keyHandler.Handle(home);
+            _keyHandler.Handle(Home);
             _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
@@ -341,8 +311,7 @@ namespace ReadLine.Tests
 
             Assert.Equal("Hello ", _keyHandler.Text);
 
-            var backspace = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
-            _keyHandler.Handle(backspace);
+            _keyHandler.Handle(Backspace);
             _keyHandler.Handle(CtrlW.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
@@ -351,9 +320,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestTab()
         {
-             var tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(tab);
-
+            _keyHandler.Handle(Tab);
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
 
@@ -362,7 +329,7 @@ namespace ReadLine.Tests
             "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 
             _completions.ToList().ForEach(completion => {
-                _keyHandler.Handle(tab);
+                _keyHandler.Handle(Tab);
                 Assert.Equal($"Hi {completion}", _keyHandler.Text);
             });
         }
@@ -370,8 +337,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestBackwardsTab()
         {
-            var tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(tab);
+            _keyHandler.Handle(Tab);
 
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
@@ -381,12 +347,10 @@ namespace ReadLine.Tests
             "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 
             // Bring up the first Autocomplete
-            tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(tab);
+            _keyHandler.Handle(Tab);
 
-            var shiftTab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
             _completions.Reverse().ToList().ForEach(completion => {
-                _keyHandler.Handle(shiftTab);
+                _keyHandler.Handle(ShiftTab);
                 Assert.Equal($"Hi {completion}", _keyHandler.Text);
             });
         }
@@ -395,8 +359,7 @@ namespace ReadLine.Tests
         public void MoveCursorThenPreviousHistory()
         {
             _keyHandler.Handle(LeftArrow);
-            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-            _keyHandler.Handle(upArrow);
+            _keyHandler.Handle(UpArrow);
 
             Assert.Equal("clear", _keyHandler.Text);
         }

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -7,12 +7,13 @@ using Xunit;
 using ReadLine.Tests.Abstractions;
 using Internal.ReadLine;
 
+using static ReadLine.Tests.CharExtensions;
+
 namespace ReadLine.Tests
 {
     public class KeyHandlerTests
     {
         private KeyHandler _keyHandler;
-        private ConsoleKeyInfo _keyInfo;
         private List<string> _history;
         private AutoCompleteHandler _autoCompleteHandler;
         private string[] _completions;
@@ -27,53 +28,28 @@ namespace ReadLine.Tests
             _console = new Console2();
             _keyHandler = new KeyHandler(_console, _history, null);
 
-            _keyInfo = new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('e', ConsoleKey.E, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('l', ConsoleKey.L, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('l', ConsoleKey.L, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('o', ConsoleKey.O, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            "Hello".Select(c => c.ToConsoleKeyInfo())
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
         }
 
         [Fact]
         public void TestWriteChar()
         {
             Assert.Equal("Hello", _keyHandler.Text);
-
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('W', ConsoleKey.W, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('o', ConsoleKey.O, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('r', ConsoleKey.R, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('l', ConsoleKey.L, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('d', ConsoleKey.D, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
+            
+            " World".Select(c => c.ToConsoleKeyInfo())
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
+                    
             Assert.Equal("Hello World", _keyHandler.Text);
         }
 
         [Fact]
         public void TestBackspace()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            var backspace = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
+            _keyHandler.Handle(backspace);
 
             Assert.Equal("Hell", _keyHandler.Text);
         }
@@ -81,10 +57,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestDelete()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false)
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hell", _keyHandler.Text);
         }
@@ -92,8 +69,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestDelete_EndOfLine()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            var delete = new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false);
+            _keyHandler.Handle(delete);
 
             Assert.Equal("Hello", _keyHandler.Text);
         }
@@ -101,8 +78,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlH()
         {
-            _keyInfo = new ConsoleKeyInfo('H', ConsoleKey.H, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            _keyHandler.Handle(CtrlH.ToConsoleKeyInfo());
 
             Assert.Equal("Hell", _keyHandler.Text);
         }
@@ -111,8 +87,7 @@ namespace ReadLine.Tests
         public void TestControlT()
         {
             var initialCursorCol = _console.CursorLeft;
-            var ctrlT = new ConsoleKeyInfo('\u0014', ConsoleKey.T, false, false, true);
-            _keyHandler.Handle(ctrlT);
+            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
 
             Assert.Equal("Helol", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -122,11 +97,12 @@ namespace ReadLine.Tests
         public void TestControlT_LeftOnce_CursorMovesToEnd()
         {
             var initialCursorCol = _console.CursorLeft;
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(leftArrow);
 
-            var ctrlT = new ConsoleKeyInfo('\u0014', ConsoleKey.T, false, false, true);
-            _keyHandler.Handle(ctrlT);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                CtrlT.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
             
             Assert.Equal("Helol", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -143,8 +119,7 @@ namespace ReadLine.Tests
 
             var initialCursorCol = _console.CursorLeft;
 
-            var ctrlT = new ConsoleKeyInfo('\u0014', ConsoleKey.T, false, false, true);
-            _keyHandler.Handle(ctrlT);
+            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
 
             Assert.Equal("Hlelo", _keyHandler.Text);
             Assert.Equal(initialCursorCol + 1, _console.CursorLeft);
@@ -153,13 +128,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlT_CursorAtBeginningOfLine_HasNoEffect()
         {
-            var ctrlA = new ConsoleKeyInfo('\u0001', ConsoleKey.A, false, false, true);
-            _keyHandler.Handle(ctrlA);
+            _keyHandler.Handle(CtrlA.ToConsoleKeyInfo());
 
             var initialCursorCol = _console.CursorLeft;
 
-            var ctrlT = new ConsoleKeyInfo('\u0014', ConsoleKey.T, false, false, true);
-            _keyHandler.Handle(ctrlT);
+            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
 
             Assert.Equal("Hello", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -168,11 +141,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestHome()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('S', ConsoleKey.S, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false),
+                'S'.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("SHello", _keyHandler.Text);
         }
@@ -180,11 +153,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlA()
         {
-            _keyInfo = new ConsoleKeyInfo('A', ConsoleKey.A, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('S', ConsoleKey.S, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>() 
+            {
+                CtrlA.ToConsoleKeyInfo(),
+                'S'.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("SHello", _keyHandler.Text);
         }
@@ -192,14 +165,12 @@ namespace ReadLine.Tests
         [Fact]
         public void TestEnd()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('!', ConsoleKey.D0, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false),
+                new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false),
+                ExclamationPoint.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -207,14 +178,12 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlE()
         {
-            _keyInfo = new ConsoleKeyInfo('A', ConsoleKey.A, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('E', ConsoleKey.E, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('!', ConsoleKey.D0, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                CtrlA.ToConsoleKeyInfo(),
+                CtrlE.ToConsoleKeyInfo(),
+                ExclamationPoint.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -222,14 +191,10 @@ namespace ReadLine.Tests
         [Fact]
         public void TestLeftArrow()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('N', ConsoleKey.N, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            " N".Select(c => c.ToConsoleKeyInfo())
+                .Prepend(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false))
+                .ToList()
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hell No", _keyHandler.Text);
         }
@@ -237,14 +202,10 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlB()
         {
-            _keyInfo = new ConsoleKeyInfo('B', ConsoleKey.B, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('N', ConsoleKey.N, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            " N".Select(c => c.ToConsoleKeyInfo())
+                .Prepend(CtrlB.ToConsoleKeyInfo())
+                .ToList()
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hell No", _keyHandler.Text);
         }
@@ -252,14 +213,12 @@ namespace ReadLine.Tests
         [Fact]
         public void TestRightArrow()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('!', ConsoleKey.D0, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false),
+                ExclamationPoint.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -267,14 +226,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlD()
         {
-            for (var i = 0; i < 4; i++)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-            }
-
-            _keyInfo = new ConsoleKeyInfo('\u0004', ConsoleKey.D, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+            Enumerable.Repeat(leftArrow, 4)
+                    .Append(CtrlD.ToConsoleKeyInfo())
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hllo", _keyHandler.Text);
         }
@@ -282,14 +238,12 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlF()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('F', ConsoleKey.F, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('!', ConsoleKey.D0, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            new List<ConsoleKeyInfo>()
+            {
+                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                CtrlF.ToConsoleKeyInfo(),
+                ExclamationPoint.ToConsoleKeyInfo()
+            }.ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -297,88 +251,69 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlL()
         {
-            _keyInfo = new ConsoleKeyInfo('L', ConsoleKey.L, false, false, true);
-            _keyHandler.Handle(_keyInfo);
-
+            _keyHandler.Handle(CtrlL.ToConsoleKeyInfo());
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
 
         [Fact]
         public void TestUpArrow()
         {
-            for (int i = _history.Count - 1; i >= 0 ; i--)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-
-                Assert.Equal(_history[i], _keyHandler.Text);
-            }
+            _history.AsEnumerable().Reverse().ToList().ForEach((history) => {
+                _keyHandler.Handle(new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false));
+                Assert.Equal(history, _keyHandler.Text);
+            });
         }
 
         [Fact]
         public void TestControlP()
         {
-            for (int i = _history.Count - 1; i >= 0 ; i--)
-            {
-                _keyInfo = new ConsoleKeyInfo('P', ConsoleKey.P, false, false, true);
-                _keyHandler.Handle(_keyInfo);
-                
-                Assert.Equal(_history[i], _keyHandler.Text);
-            }
+            _history.AsEnumerable().Reverse().ToList().ForEach((history) => {
+                _keyHandler.Handle(CtrlP.ToConsoleKeyInfo());
+                Assert.Equal(history, _keyHandler.Text);
+            });
         }
 
         [Fact]
         public void TestDownArrow()
         {
-            for (int i = _history.Count - 1; i >= 0 ; i--)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-            }
+            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
+            Enumerable.Repeat(upArrow, _history.Count)
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
 
-            for (int i = 0; i < _history.Count; i++)
-            {
-                Assert.Equal(_history[i], _keyHandler.Text);
-
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-            }
+            var downArrow = new ConsoleKeyInfo('\0', ConsoleKey.DownArrow, false, false, false);
+            _history.ForEach( history => {
+                Assert.Equal(history, _keyHandler.Text);
+                _keyHandler.Handle(downArrow);
+            });
         }
 
         [Fact]
         public void TestControlN()
         {
-            for (int i = _history.Count - 1; i >= 0 ; i--)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-            }
+            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
+            Enumerable.Repeat(upArrow, _history.Count)
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
 
-            for (int i = 0; i < _history.Count; i++)
-            {
-                Assert.Equal(_history[i], _keyHandler.Text);
-                
-                _keyInfo = new ConsoleKeyInfo('N', ConsoleKey.N, false, false, true);
-                _keyHandler.Handle(_keyInfo);
-            }
+            _history.ForEach( history => {
+                Assert.Equal(history, _keyHandler.Text);
+                _keyHandler.Handle(CtrlN.ToConsoleKeyInfo());
+            });
         }
 
         [Fact]
         public void TestControlU()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('U', ConsoleKey.U, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+            _keyHandler.Handle(leftArrow);
+            _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
 
             Assert.Equal("o", _keyHandler.Text);
 
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('U', ConsoleKey.U, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var end = new ConsoleKeyInfo('\0', ConsoleKey.End, false, false, false);
+            _keyHandler.Handle(end);
+            _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
@@ -386,19 +321,15 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlK()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('K', ConsoleKey.K, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+            _keyHandler.Handle(leftArrow);
+            _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
 
             Assert.Equal("Hell", _keyHandler.Text);
 
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('K', ConsoleKey.K, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var home = new ConsoleKeyInfo('\0', ConsoleKey.Home, false, false, false);
+            _keyHandler.Handle(home);
+            _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
@@ -406,34 +337,16 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlW()
         {
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('W', ConsoleKey.W, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('o', ConsoleKey.O, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('r', ConsoleKey.R, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('l', ConsoleKey.L, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('d', ConsoleKey.D, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('W', ConsoleKey.W, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            " World".Append(CtrlW)
+                    .Select(c => c.ToConsoleKeyInfo())
+                    .ToList()
+                    .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello ", _keyHandler.Text);
 
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('W', ConsoleKey.W, false, false, true);
-            _keyHandler.Handle(_keyInfo);
+            var backspace = new ConsoleKeyInfo('\0', ConsoleKey.Backspace, false, false, false);
+            _keyHandler.Handle(backspace);
+            _keyHandler.Handle(CtrlW.ToConsoleKeyInfo());
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
@@ -441,63 +354,55 @@ namespace ReadLine.Tests
         [Fact]
         public void TestTab()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+             var tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+            _keyHandler.Handle(tab);
 
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
 
             _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler);
 
-            _keyInfo = new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 
-            _keyInfo = new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            for (int i = 0; i < _completions.Length; i++)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-                _keyHandler.Handle(_keyInfo);
-
-                Assert.Equal($"Hi {_completions[i]}", _keyHandler.Text);
-            }
+            _completions.ToList().ForEach(completion => {
+                _keyHandler.Handle(tab);
+                Assert.Equal($"Hi {completion}", _keyHandler.Text);
+            });
         }
 
         [Fact]
         public void TestBackwardsTab()
         {
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            var tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+            _keyHandler.Handle(tab);
 
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
 
             _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler);
 
-            _keyInfo = new ConsoleKeyInfo('H', ConsoleKey.H, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo('i', ConsoleKey.I, false, false, false);
-            _keyHandler.Handle(_keyInfo);
-
-            _keyInfo = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 
             // Bring up the first Autocomplete
-            _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
-            _keyHandler.Handle(_keyInfo);
+            tab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, false, false, false);
+            _keyHandler.Handle(tab);
 
-            for (int i = _completions.Length - 1; i >= 0; i--)
-            {
-                _keyInfo = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
-                _keyHandler.Handle(_keyInfo);
+            var shiftTab = new ConsoleKeyInfo('\0', ConsoleKey.Tab, true, false, false);
+            _completions.Reverse().ToList().ForEach(completion => {
+                _keyHandler.Handle(shiftTab);
+                Assert.Equal($"Hi {completion}", _keyHandler.Text);
+            });
+        }
 
-                Assert.Equal($"Hi {_completions[i]}", _keyHandler.Text);
-            }
+        [Fact]
+        public void MoveCursorThenPreviousHistory()
+        {
+            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
+            _keyHandler.Handle(leftArrow);
+            var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
+            _keyHandler.Handle(upArrow);
+
+            Assert.Equal("clear", _keyHandler.Text);
         }
     }
 }

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -8,6 +8,7 @@ using ReadLine.Tests.Abstractions;
 using Internal.ReadLine;
 
 using static ReadLine.Tests.CharExtensions;
+using static ReadLine.Tests.ConsoleKeyInfoExtensions;
 
 namespace ReadLine.Tests
 {
@@ -59,7 +60,7 @@ namespace ReadLine.Tests
         {
             new List<ConsoleKeyInfo>()
             {
-                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                LeftArrow,
                 new ConsoleKeyInfo('\0', ConsoleKey.Delete, false, false, false)
             }.ForEach(_keyHandler.Handle);
 
@@ -100,7 +101,7 @@ namespace ReadLine.Tests
 
             new List<ConsoleKeyInfo>()
             {
-                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                LeftArrow,
                 CtrlT.ToConsoleKeyInfo()
             }.ForEach(_keyHandler.Handle);
             
@@ -111,9 +112,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlT_CursorInMiddleOfLine()
         {
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
             Enumerable
-                .Repeat(leftArrow, 3)
+                .Repeat(LeftArrow, 3)
                 .ToList()
                 .ForEach(_keyHandler.Handle);
 
@@ -192,7 +192,7 @@ namespace ReadLine.Tests
         public void TestLeftArrow()
         {
             " N".Select(c => c.ToConsoleKeyInfo())
-                .Prepend(new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false))
+                .Prepend(LeftArrow)
                 .ToList()
                 .ForEach(_keyHandler.Handle);
 
@@ -215,7 +215,7 @@ namespace ReadLine.Tests
         {
             new List<ConsoleKeyInfo>()
             {
-                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                LeftArrow,
                 new ConsoleKeyInfo('\0', ConsoleKey.RightArrow, false, false, false),
                 ExclamationPoint.ToConsoleKeyInfo()
             }.ForEach(_keyHandler.Handle);
@@ -226,8 +226,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlD()
         {
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            Enumerable.Repeat(leftArrow, 4)
+            Enumerable.Repeat(LeftArrow, 4)
                     .Append(CtrlD.ToConsoleKeyInfo())
                     .ToList()
                     .ForEach(_keyHandler.Handle);
@@ -240,7 +239,7 @@ namespace ReadLine.Tests
         {
             new List<ConsoleKeyInfo>()
             {
-                new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false),
+                LeftArrow,
                 CtrlF.ToConsoleKeyInfo(),
                 ExclamationPoint.ToConsoleKeyInfo()
             }.ForEach(_keyHandler.Handle);
@@ -305,8 +304,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlU()
         {
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(leftArrow);
+            _keyHandler.Handle(LeftArrow);
             _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
 
             Assert.Equal("o", _keyHandler.Text);
@@ -321,8 +319,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlK()
         {
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(leftArrow);
+            _keyHandler.Handle(LeftArrow);
             _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
 
             Assert.Equal("Hell", _keyHandler.Text);
@@ -397,8 +394,7 @@ namespace ReadLine.Tests
         [Fact]
         public void MoveCursorThenPreviousHistory()
         {
-            var leftArrow = new ConsoleKeyInfo('\0', ConsoleKey.LeftArrow, false, false, false);
-            _keyHandler.Handle(leftArrow);
+            _keyHandler.Handle(LeftArrow);
             var upArrow = new ConsoleKeyInfo('\0', ConsoleKey.UpArrow, false, false, false);
             _keyHandler.Handle(upArrow);
 

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 using ReadLine.Tests.Abstractions;
 using Internal.ReadLine;
 
-using static ReadLine.Tests.CharExtensions;
 using static ReadLine.Tests.ConsoleKeyInfoExtensions;
 
 namespace ReadLine.Tests
@@ -72,7 +71,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlH()
         {
-            _keyHandler.Handle(CtrlH.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlH);
             Assert.Equal("Hell", _keyHandler.Text);
         }
 
@@ -80,7 +79,7 @@ namespace ReadLine.Tests
         public void TestControlT()
         {
             var initialCursorCol = _console.CursorLeft;
-            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlT);
 
             Assert.Equal("Helol", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -91,7 +90,7 @@ namespace ReadLine.Tests
         {
             var initialCursorCol = _console.CursorLeft;
 
-            new List<ConsoleKeyInfo>() { LeftArrow, CtrlT.ToConsoleKeyInfo() }
+            new List<ConsoleKeyInfo>() { LeftArrow, CtrlT }
                 .ForEach(_keyHandler.Handle);
             
             Assert.Equal("Helol", _keyHandler.Text);
@@ -108,7 +107,7 @@ namespace ReadLine.Tests
 
             var initialCursorCol = _console.CursorLeft;
 
-            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlT);
 
             Assert.Equal("Hlelo", _keyHandler.Text);
             Assert.Equal(initialCursorCol + 1, _console.CursorLeft);
@@ -117,11 +116,11 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlT_CursorAtBeginningOfLine_HasNoEffect()
         {
-            _keyHandler.Handle(CtrlA.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlA);
 
             var initialCursorCol = _console.CursorLeft;
 
-            _keyHandler.Handle(CtrlT.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlT);
 
             Assert.Equal("Hello", _keyHandler.Text);
             Assert.Equal(initialCursorCol, _console.CursorLeft);
@@ -139,7 +138,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlA()
         {
-            new List<ConsoleKeyInfo>() { CtrlA.ToConsoleKeyInfo(), 'S'.ToConsoleKeyInfo() }
+            new List<ConsoleKeyInfo>() { CtrlA, 'S'.ToConsoleKeyInfo() }
                 .ForEach(_keyHandler.Handle);
 
             Assert.Equal("SHello", _keyHandler.Text);
@@ -148,7 +147,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestEnd()
         {
-            new List<ConsoleKeyInfo>() { Home, End, ExclamationPoint.ToConsoleKeyInfo() }
+            new List<ConsoleKeyInfo>() { Home, End, ExclamationPoint }
                 .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
@@ -157,12 +156,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlE()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                CtrlA.ToConsoleKeyInfo(),
-                CtrlE.ToConsoleKeyInfo(),
-                ExclamationPoint.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { CtrlA, CtrlE, ExclamationPoint }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -182,7 +177,7 @@ namespace ReadLine.Tests
         public void TestControlB()
         {
             " N".Select(c => c.ToConsoleKeyInfo())
-                .Prepend(CtrlB.ToConsoleKeyInfo())
+                .Prepend(CtrlB)
                 .ToList()
                 .ForEach(_keyHandler.Handle);
 
@@ -192,7 +187,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestRightArrow()
         {
-            new List<ConsoleKeyInfo>() { LeftArrow, RightArrow, ExclamationPoint.ToConsoleKeyInfo() }
+            new List<ConsoleKeyInfo>() { LeftArrow, RightArrow, ExclamationPoint }
                 .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
@@ -202,7 +197,7 @@ namespace ReadLine.Tests
         public void TestControlD()
         {
             Enumerable.Repeat(LeftArrow, 4)
-                    .Append(CtrlD.ToConsoleKeyInfo())
+                    .Append(CtrlD)
                     .ToList()
                     .ForEach(_keyHandler.Handle);
 
@@ -212,12 +207,8 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlF()
         {
-            new List<ConsoleKeyInfo>()
-            {
-                LeftArrow,
-                CtrlF.ToConsoleKeyInfo(),
-                ExclamationPoint.ToConsoleKeyInfo()
-            }.ForEach(_keyHandler.Handle);
+            new List<ConsoleKeyInfo>() { LeftArrow, CtrlF, ExclamationPoint }
+                .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello!", _keyHandler.Text);
         }
@@ -225,7 +216,7 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlL()
         {
-            _keyHandler.Handle(CtrlL.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlL);
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
 
@@ -242,7 +233,7 @@ namespace ReadLine.Tests
         public void TestControlP()
         {
             _history.AsEnumerable().Reverse().ToList().ForEach((history) => {
-                _keyHandler.Handle(CtrlP.ToConsoleKeyInfo());
+                _keyHandler.Handle(CtrlP);
                 Assert.Equal(history, _keyHandler.Text);
             });
         }
@@ -269,7 +260,7 @@ namespace ReadLine.Tests
 
             _history.ForEach( history => {
                 Assert.Equal(history, _keyHandler.Text);
-                _keyHandler.Handle(CtrlN.ToConsoleKeyInfo());
+                _keyHandler.Handle(CtrlN);
             });
         }
 
@@ -277,12 +268,12 @@ namespace ReadLine.Tests
         public void TestControlU()
         {
             _keyHandler.Handle(LeftArrow);
-            _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlU);
 
             Assert.Equal("o", _keyHandler.Text);
 
             _keyHandler.Handle(End);
-            _keyHandler.Handle(CtrlU.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlU);
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
@@ -291,12 +282,12 @@ namespace ReadLine.Tests
         public void TestControlK()
         {
             _keyHandler.Handle(LeftArrow);
-            _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlK);
 
             Assert.Equal("Hell", _keyHandler.Text);
 
             _keyHandler.Handle(Home);
-            _keyHandler.Handle(CtrlK.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlK);
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }
@@ -304,15 +295,15 @@ namespace ReadLine.Tests
         [Fact]
         public void TestControlW()
         {
-            " World".Append(CtrlW)
-                    .Select(c => c.ToConsoleKeyInfo())
+            " World".Select(c => c.ToConsoleKeyInfo())
+                    .Append(CtrlW)
                     .ToList()
                     .ForEach(_keyHandler.Handle);
 
             Assert.Equal("Hello ", _keyHandler.Text);
 
             _keyHandler.Handle(Backspace);
-            _keyHandler.Handle(CtrlW.ToConsoleKeyInfo());
+            _keyHandler.Handle(CtrlW);
 
             Assert.Equal(string.Empty, _keyHandler.Text);
         }


### PR DESCRIPTION
I was having a bit of trouble following the tests at times.
This PR extracts a lot of the commonly duplicated code for creating `ConsoleKeyInfo` instances.
It also converts manual `for` loops into maps for readability.
I'm hoping this helps keep the tests maintainable into the future.

The new extension classes may or may not be useful in the main code base.
I didn't think about how they might be leveraged elsewhere yet.