### PR TITLE
Improve screen repaint speed

### DIFF
--- a/src/ReadLine.Demo/Program.cs
+++ b/src/ReadLine.Demo/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace ConsoleApplication
 {
@@ -10,7 +11,7 @@ namespace ConsoleApplication
             Console.WriteLine("---------------------");
             Console.WriteLine();
 
-            string[] history = new string[] { "ls -a", "dotnet run", "git init" };
+            var history = new List<string> { "ls -a", "dotnet run", "git init" };
             ReadLine.AddHistory(history);
 
             ReadLine.AutoCompletionHandler = new AutoCompletionHandler();
@@ -31,7 +32,7 @@ namespace ConsoleApplication
             if (text.StartsWith("git "))
                 return new string[] { "init", "clone", "pull", "push" };
             else
-                return null;
+                return new string[] { "git", "ls", "cd", "pwd" };
         }
     }
 }

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -1,6 +1,6 @@
 ﻿using Internal.ReadLine;
 using Internal.ReadLine.Abstractions;
-
+using System;
 using System.Collections.Generic;
 
 namespace System
@@ -14,7 +14,16 @@ namespace System
             _history = new List<string>();
         }
 
-        public static void AddHistory(params string[] text) => _history.AddRange(text);
+        public static void AddHistory(List<string> text)
+        {
+            _history.AddRange(text);
+        }
+
+        public static void AddHistory(string text)
+        {
+            _history.Add(text);
+        }
+        
         public static List<string> GetHistory() => _history;
         public static void ClearHistory() => _history = new List<string>();
         public static bool HistoryEnabled { get; set; }
@@ -23,7 +32,7 @@ namespace System
         public static string Read(string prompt = "", string @default = "")
         {
             Console.Write(prompt);
-            KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
+            KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler, prompt.Length);
             string text = GetText(keyHandler);
 
             if (String.IsNullOrWhiteSpace(text) && !String.IsNullOrWhiteSpace(@default))
@@ -32,18 +41,29 @@ namespace System
             }
             else
             {
-                if (HistoryEnabled)
-                    _history.Add(text);
+                if (HistoryEnabled && !string.IsNullOrWhiteSpace(text))
+                {
+                    if ((_history.Count == 0) || (_history[_history.Count-1] != text))
+                    {
+                        _history.Add(text);
+                    }
+                }
             }
-
             return text;
         }
 
         public static string ReadPassword(string prompt = "")
         {
             Console.Write(prompt);
-            KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
-            return GetText(keyHandler);
+            KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null, prompt.Length);
+            return Reverse(GetText(keyHandler));
+        }
+
+        public static string Reverse( string s )
+        {
+            char[] charArray = s.ToCharArray();
+            Array.Reverse( charArray );
+            return new string( charArray );
         }
 
         private static string GetText(KeyHandler keyHandler)

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -23,10 +23,10 @@ namespace ReadLine.Tests
         {
             _autoCompleteHandler = new AutoCompleteHandler();
             _completions = _autoCompleteHandler.GetSuggestions("", 0);
-            _history = new List<string>(new string[] { "dotnet run", "git init", "clear" });
+            _history = new List<string>() { "dotnet run", "git init", "clear" };
 
             _console = new Console2();
-            _keyHandler = new KeyHandler(_console, _history, null);
+            _keyHandler = new KeyHandler(_console, _history, null, 0);
 
             "Hello".Select(c => c.ToConsoleKeyInfo())
                     .ToList()
@@ -315,7 +315,7 @@ namespace ReadLine.Tests
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
 
-            _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler);
+            _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler, 0);
 
             "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 
@@ -333,7 +333,7 @@ namespace ReadLine.Tests
             // Nothing happens when no auto complete handler is set
             Assert.Equal("Hello", _keyHandler.Text);
 
-            _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler);
+            _keyHandler = new KeyHandler(new Console2(), _history, _autoCompleteHandler, 0);
 
             "Hi ".Select(c => c.ToConsoleKeyInfo()).ToList().ForEach(_keyHandler.Handle);
 

--- a/test/ReadLine.Tests/ReadLineTests.cs
+++ b/test/ReadLine.Tests/ReadLineTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Generic;
 using Xunit;
 
 using static System.ReadLine;
@@ -10,7 +11,7 @@ namespace ReadLine.Tests
     {
         public ReadLineTests()
         {
-            string[] history = new string[] { "ls -a", "dotnet run", "git init" };
+            var history = new List<string>() { "ls -a", "dotnet run", "git init" };
             AddHistory(history);
         }
 


### PR DESCRIPTION
Ideally, I'd like to see conversion to Generic Lists over arrays everywhere, but these mods made this library much easier to integrate into one of my other projects.

The other issue is that by keeping track of the cursor pointer and changing one char at a time, it's slow and the repaint factor is frustrating for a user used to the native GNU tools on *nix. I modified the logic to cut to the chase and quickly repaint the affected text whole strings at a time instead of per char.

Neat project overall-- thanks for sharing. I hope these changes are helpful to your goals.