### PR TITLE
Fix word cutting logic (C-w)

### DIFF
--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -238,6 +238,14 @@ namespace Internal.ReadLine
             _completionsIndex = 0;
         }
 
+        private int GetPreviousWordPosition()
+        {
+            int pos = _cursorPos - 1;
+            while (pos > 0 && _text[pos] == ' ') pos -= 1;
+            while (pos >= 0 && _text[pos] != ' ') pos -= 1;
+            return pos + 1;
+        }
+
         public string Text
         {
             get
@@ -287,7 +295,8 @@ namespace Internal.ReadLine
             };
             _keyActions["ControlW"] = () =>
             {
-                while (!IsStartOfLine() && _text[_cursorPos - 1] != ' ')
+                int targetPos = GetPreviousWordPosition();
+                while (!IsStartOfLine() && _cursorPos > targetPos)
                     Backspace();
             };
             _keyActions["ControlT"] = TransposeChars;


### PR DESCRIPTION
Hi,

Thanks for creating an awesome project.

Current implementation of (C-w) does not correctly cut a word when the word is followed by some space characters. For example, suppose we have a line with 10 characters: `aaa bbb ccc`, and the cursor is located at the end. When we press (C-W), we will cut the word `ccc` correctly for the first time, but the next time we press (C-W), Readline will fail to delete the word `bbb`, because there is a space char followed by the word.

This PR fixes this issue.
