### PR TITLE
Add support for CancellationToken on Read/ReadPassword

### DIFF
--- a/src/ReadLine.Demo/Program.cs
+++ b/src/ReadLine.Demo/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 namespace ConsoleApplication
 {
     public class Program
@@ -20,6 +22,57 @@ namespace ConsoleApplication
 
             input = ReadLine.ReadPassword("Enter Password> ");
             Console.WriteLine(input);
+
+            using (CancellationTokenSource cts = new CancellationTokenSource(5000))
+            {
+                
+                try {
+                    input = ReadLine.Read($"prompt [5 sec]> ",cancellationToken: cts.Token);
+                    Console.WriteLine($"Result: {input}");
+                }
+                catch (OperationCanceledException)
+                {
+                    Console.WriteLine(" [Operation was aborted]");
+                }
+            }
+            
+            int interrupted=0;
+            Console.Write("Reading several lines using ReadKey [Terminate with CTRL+Q]: ");
+            StringBuilder sb = new StringBuilder();
+            while (true)
+                using (CancellationTokenSource cts=new CancellationTokenSource(10)) //10 ms to stress the loop
+                {
+                    try
+                    {
+                        var rki=ReadLine.ReadKey(cancellationToken: cts.Token);
+                        if (rki.KeyChar=='\u0011') // CTRL-Q in unicode
+                            break;
+                        sb.Append(rki.KeyChar);
+                        if (rki.KeyChar=='\r')
+                            sb.Append('\n');
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        interrupted++;
+                    }
+                }
+            Console.WriteLine("ReadKey was interrupted {0} times during read",interrupted);
+            Console.WriteLine("Entered value:");
+            Console.WriteLine("---------------------");
+            Console.WriteLine(sb.ToString());
+            Console.WriteLine("---------------------");
+            
+            using (CancellationTokenSource cts = new CancellationTokenSource(5000))
+            {
+                try {
+                    input=ReadLine.ReadAsync("Reading line in a Task (5 secs before cancellation)>",cts.Token).GetAwaiter().GetResult();
+                    Console.WriteLine(input);
+                }
+                catch (OperationCanceledException)
+                {
+                    Console.WriteLine(" [Interupted by timer]");
+                }
+            }
         }
     }
 

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -2,16 +2,29 @@
 using Internal.ReadLine.Abstractions;
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System
 {
     public static class ReadLine
     {
         private static List<string> _history;
-
+        private static Thread _reader;
+        private static ManualResetEventSlim _getInput, _gotInput;
+        private static ConsoleKeyInfo  _input;
+        private static object _lock = new object();
+  
         static ReadLine()
         {
             _history = new List<string>();
+            _getInput = new ManualResetEventSlim();
+            _gotInput = new ManualResetEventSlim();
+            _reader = new Thread(ReaderLoop) {
+                 IsBackground = true,
+                 Name = "ReadLine background reader Loop"
+            };
+            _reader.Start();
         }
 
         public static void AddHistory(params string[] text) => _history.AddRange(text);
@@ -19,12 +32,12 @@ namespace System
         public static void ClearHistory() => _history = new List<string>();
         public static bool HistoryEnabled { get; set; }
         public static IAutoCompleteHandler AutoCompletionHandler { private get; set; }
-
-        public static string Read(string prompt = "", string @default = "")
+        
+        public static string Read(string prompt = "", string @default = "", CancellationToken cancellationToken=default)
         {
             Console.Write(prompt);
             KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
-            string text = GetText(keyHandler);
+            string text = GetText(keyHandler,cancellationToken);
 
             if (String.IsNullOrWhiteSpace(text) && !String.IsNullOrWhiteSpace(@default))
             {
@@ -39,24 +52,63 @@ namespace System
             return text;
         }
 
-        public static string ReadPassword(string prompt = "")
+        public static string ReadPassword(string prompt = "",CancellationToken cancellationToken=default)
         {
             Console.Write(prompt);
             KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
-            return GetText(keyHandler);
+            return GetText(keyHandler,cancellationToken);
         }
 
-        private static string GetText(KeyHandler keyHandler)
+        private static string GetText(KeyHandler keyHandler,CancellationToken cancellationToken)
         {
-            ConsoleKeyInfo keyInfo = Console.ReadKey(true);
+            ConsoleKeyInfo keyInfo = ReadKeyInternal(cancellationToken);
             while (keyInfo.Key != ConsoleKey.Enter)
             {
                 keyHandler.Handle(keyInfo);
-                keyInfo = Console.ReadKey(true);
+                keyInfo = ReadKeyInternal(cancellationToken);
             }
 
             Console.WriteLine();
             return keyHandler.Text;
+        }
+
+        public static ConsoleKeyInfo ReadKey(bool intercept = false, CancellationToken cancellationToken=default)
+        {
+            ConsoleKeyInfo consoleKeyInfo=ReadKeyInternal(cancellationToken);
+            if (!intercept)
+            {
+                if (consoleKeyInfo.Key==ConsoleKey.Enter)
+                    Console.WriteLine();
+                else
+                    Console.Write(consoleKeyInfo.KeyChar);
+            }
+            return consoleKeyInfo;
+        }
+
+        public static Task<string> ReadAsync(string prompt,CancellationToken cancellationToken)
+        {
+            return Task.Run(()=>ReadLine.Read(prompt,cancellationToken: cancellationToken));
+        }
+
+        private static ConsoleKeyInfo ReadKeyInternal(CancellationToken cancellation)
+        {
+            if (!_gotInput.IsSet)
+            {
+                _getInput.Set();
+                _gotInput.Wait(cancellation);
+            }
+            _gotInput.Reset();
+            return _input;
+        }
+        
+        private static void ReaderLoop()
+        {
+            while (true) {
+                _getInput.Wait();
+                _input = Console.ReadKey(true); 
+                _getInput.Reset();
+                _gotInput.Set();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds CancellationToken to the Read and ReadPassword API.

Functionalities:
- CancellationToken for Read and ReadPassword
- Async API: ReadAsync
- ReadKey to read a single key that mimics Console.ReadKey(bool)

This change is constructed using a background thread that perform readkey on the console and exchange them with the API calling thread using synchronization events. This approach avoid recurrent pulling on the Console.KeyAvailable.

**Credits:** This change was heavily inspired by 'JSquareD' answer on the following post: https://stackoverflow.com/questions/57615/how-to-add-a-timeout-to-console-readline
