### PR TITLE
Add two new ways to customize the readline

### DIFF
--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -246,7 +246,7 @@ namespace Internal.ReadLine
             }
         }
 
-        public KeyHandler(IConsole console, List<string> history, IAutoCompleteHandler autoCompleteHandler)
+        public KeyHandler(IConsole console, List<string> history, IAutoCompleteHandler autoCompleteHandler, Dictionary<string, Action> keyHandlers = null)
         {
             Console2 = console;
 
@@ -325,6 +325,22 @@ namespace Internal.ReadLine
                     PreviousAutoComplete();
                 }
             };
+
+            // do overrides and additional handlers.
+            if (_keyActions != null)
+            {
+                foreach (var kvp in keyHandlers)
+                {
+                    if (_keyActions.ContainsKey(kvp.Key))
+                    {
+                        _keyActions[kvp.Key] = kvp.Value;
+                    }
+                    else
+                    {
+                        _keyActions.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
         }
 
         public void Handle(ConsoleKeyInfo keyInfo)

--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -327,7 +327,7 @@ namespace Internal.ReadLine
             };
 
             // do overrides and additional handlers.
-            if (_keyActions != null)
+            if (keyHandlers != null)
             {
                 foreach (var kvp in keyHandlers)
                 {

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -19,11 +19,13 @@ namespace System
         public static void ClearHistory() => _history = new List<string>();
         public static bool HistoryEnabled { get; set; }
         public static IAutoCompleteHandler AutoCompletionHandler { private get; set; }
+        public static Dictionary<string, Action> KeyHandlers { private get; set; }
+        public static Action<string> WritePrompt { private get; set; } = (prompt) => Console.Write(prompt);
 
         public static string Read(string prompt = "", string @default = "")
         {
-            Console.Write(prompt);
-            KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
+            WritePrompt(prompt);
+            KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler, KeyHandlers);
             string text = GetText(keyHandler);
 
             if (String.IsNullOrWhiteSpace(text) && !String.IsNullOrWhiteSpace(@default))
@@ -41,7 +43,7 @@ namespace System
 
         public static string ReadPassword(string prompt = "")
         {
-            Console.Write(prompt);
+            WritePrompt(prompt);
             KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
             return GetText(keyHandler);
         }


### PR DESCRIPTION
Add ability to add additional key handlers
Add ability to override existing key handlers
  - if a user wants to add specific key handling not covered in the defaults, or if they want to change how a specific key is handled this will allow them to pass in their own handlers.

Add ability to override how the prompt is written
  - User may want to change the color of the prompt. by providing their own 
     function to write the prompt it allows for customization and including data
     from their own context in the prompt information of their cli.