### PR TITLE
Solves a bug when typing Control+LeftArrow and other similar combinations

### DIFF
--- a/src/ReadLine.Demo/Program.cs
+++ b/src/ReadLine.Demo/Program.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace ConsoleApplication
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static void Main()
         {
             Console.WriteLine("ReadLine Library Demo");
             Console.WriteLine("---------------------");
             Console.WriteLine();
 
-            string[] history = new string[] { "ls -a", "dotnet run", "git init" };
+            string[] history = ["ls -a", "dotnet run", "git init"];
             ReadLine.AddHistory(history);
 
             ReadLine.AutoCompletionHandler = new AutoCompletionHandler();
@@ -25,11 +27,11 @@ namespace ConsoleApplication
 
     class AutoCompletionHandler : IAutoCompleteHandler
     {
-        public char[] Separators { get; set; } = new char[] { ' ', '.', '/', '\\', ':' };
+        public char[] Separators { get; set; } = [' ', '.', '/', '\\', ':'];
         public string[] GetSuggestions(string text, int index)
         {
             if (text.StartsWith("git "))
-                return new string[] { "init", "clone", "pull", "push" };
+                return ["init", "clone", "pull", "push"];
             else
                 return null;
         }

--- a/src/ReadLine.Demo/ReadLine.Demo.csproj
+++ b/src/ReadLine.Demo/ReadLine.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>ReadLine.Demo</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/ReadLine/GlobalSuppressions.cs
+++ b/src/ReadLine/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "<Pending>", Scope = "namespace", Target = "~N:System")]
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "<Pending>", Scope = "namespace", Target = "~N:Internal.ReadLine")]

--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -93,7 +93,12 @@ namespace Internal.ReadLine
                 WriteChar(character);
         }
 
-        private void WriteChar() => WriteChar(_keyInfo.KeyChar);
+        private void WriteChar() {
+            // solves bug when typing things like ControlLeftArrow...
+            // maybe we should only write printable characters...
+            if (_keyInfo.KeyChar !=  '\0')
+                WriteChar(_keyInfo.KeyChar);
+        }
 
         private void WriteChar(char c)
         {

--- a/src/ReadLine/ReadLine.cs
+++ b/src/ReadLine/ReadLine.cs
@@ -11,19 +11,19 @@ namespace System
 
         static ReadLine()
         {
-            _history = new List<string>();
+            _history = [];
         }
 
         public static void AddHistory(params string[] text) => _history.AddRange(text);
         public static List<string> GetHistory() => _history;
-        public static void ClearHistory() => _history = new List<string>();
+        public static void ClearHistory() => _history = [];
         public static bool HistoryEnabled { get; set; }
         public static IAutoCompleteHandler AutoCompletionHandler { private get; set; }
 
         public static string Read(string prompt = "", string @default = "")
         {
             Console.Write(prompt);
-            KeyHandler keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
+            var keyHandler = new KeyHandler(new Console2(), _history, AutoCompletionHandler);
             string text = GetText(keyHandler);
 
             if (String.IsNullOrWhiteSpace(text) && !String.IsNullOrWhiteSpace(@default))
@@ -42,7 +42,7 @@ namespace System
         public static string ReadPassword(string prompt = "")
         {
             Console.Write(prompt);
-            KeyHandler keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
+            var keyHandler = new KeyHandler(new Console2() { PasswordMode = true }, null, null);
             return GetText(keyHandler);
         }
 

--- a/src/ReadLine/ReadLine.csproj
+++ b/src/ReadLine/ReadLine.csproj
@@ -15,6 +15,7 @@
     <PackageLicenseUrl>https://github.com/tonerdo/readline/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tonerdo/readline</RepositoryUrl>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/test/ReadLine.Tests/CharExtensions.cs
+++ b/test/ReadLine.Tests/CharExtensions.cs
@@ -22,7 +22,7 @@ namespace ReadLine.Tests
         public const char CtrlU = '\u0015';
         public const char CtrlW = '\u0017';
 
-        private static readonly Dictionary<char, Tuple<ConsoleKey, ConsoleModifiers>> specialKeyCharMap = new Dictionary<char, Tuple<ConsoleKey, ConsoleModifiers>>() 
+        private static readonly Dictionary<char, Tuple<ConsoleKey, ConsoleModifiers>> specialKeyCharMap = new() 
         {
             {ExclamationPoint, Tuple.Create(ConsoleKey.D0, NoModifiers())},
             {Space, Tuple.Create(ConsoleKey.Spacebar,  NoModifiers())},

--- a/test/ReadLine.Tests/KeyHandlerTests.cs
+++ b/test/ReadLine.Tests/KeyHandlerTests.cs
@@ -14,16 +14,16 @@ namespace ReadLine.Tests
     public class KeyHandlerTests
     {
         private KeyHandler _keyHandler;
-        private List<string> _history;
-        private AutoCompleteHandler _autoCompleteHandler;
-        private string[] _completions;
-        private Internal.ReadLine.Abstractions.IConsole _console;
+        private readonly List<string> _history;
+        private readonly AutoCompleteHandler _autoCompleteHandler;
+        private readonly string[] _completions;
+        private readonly Internal.ReadLine.Abstractions.IConsole _console;
 
         public KeyHandlerTests()
         {
             _autoCompleteHandler = new AutoCompleteHandler();
             _completions = _autoCompleteHandler.GetSuggestions("", 0);
-            _history = new List<string>(new string[] { "dotnet run", "git init", "clear" });
+            _history = new List<string>(["dotnet run", "git init", "clear"]);
 
             _console = new Console2();
             _keyHandler = new KeyHandler(_console, _history, null);

--- a/test/ReadLine.Tests/ReadLine.Tests.csproj
+++ b/test/ReadLine.Tests/ReadLine.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>ReadLine.Tests</AssemblyName>
     <PackageId>ReadLine.Tests</PackageId>
@@ -12,9 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When typing Control+LeftArrow (and other similar key combinations) the \0 char was being written to the console which was causing havoc in typing. This commit fixes it by preventing writing of the \0 char, but, maybe we should prevent writing non-printable characters altogether.