### PR TITLE
Solves a bug when typing Control+LeftArrow and other similar combinations

### DIFF
--- a/src/ReadLine/KeyHandler.cs
+++ b/src/ReadLine/KeyHandler.cs
@@ -93,7 +93,12 @@ namespace Internal.ReadLine
                 WriteChar(character);
         }
 
-        private void WriteChar() => WriteChar(_keyInfo.KeyChar);
+        private void WriteChar() {
+            // solves bug when typing things like ControlLeftArrow...
+            // maybe we should only write printable characters...
+            if (_keyInfo.KeyChar !=  '\0')
+                WriteChar(_keyInfo.KeyChar);
+        }
 
         private void WriteChar(char c)
         {


### PR DESCRIPTION
When typing Control+LeftArrow (and other similar key combinations) the \0 char was being written to the console which was causing havoc in typing. This commit fixes it by preventing writing the \0 char, but, maybe we should prevent writing non-printable characters altogether